### PR TITLE
refactor(terminal.sass): nest input styling within .terminal to stop …

### DIFF
--- a/client/src/components/Lesson/Terminal/Terminal.sass
+++ b/client/src/components/Lesson/Terminal/Terminal.sass
@@ -1,13 +1,3 @@
-input
-  background-color: $primary-color
-  font-family: $content-text
-  font-size: $font-size-content
-  color: $text-on-color
-  padding: 0 0.55em 0.7em
-
-  &:focus
-    outline: none
-
 .terminal
   display: flex
   flex-direction: column-reverse
@@ -15,3 +5,13 @@ input
   height: 100%
   width: 75%
   @include pixel-borders($corner-size: 2, $border-color: $secondary-color)
+
+  input
+    background-color: $primary-color
+    font-family: $content-text
+    font-size: $font-size-content
+    color: $text-on-color
+    padding: 0 0.55em 0.7em
+
+  &:focus
+    outline: none


### PR DESCRIPTION
…app-wide input styling